### PR TITLE
Tatt bort duplikater

### DIFF
--- a/KS.Fiks.Plan.Models.V2/Meldingstyper/FiksPlanMeldingtypeV2.cs
+++ b/KS.Fiks.Plan.Models.V2/Meldingstyper/FiksPlanMeldingtypeV2.cs
@@ -129,8 +129,6 @@ namespace KS.Fiks.Plan.Models.V2.Meldingstyper
             MottattRegistrerMidlertidigForbudMotTiltak,
             KvitteringRegistrerMidlertidigForbudMotTiltak,
             OppdaterArealplan,
-            MottattOppdaterArealplan,
-            KvitteringOppdaterArealplan,
             RegistrerDispensasjon,
             MottattRegistrerDispensasjon,
             KvitteringRegistrerDispensasjon,


### PR DESCRIPTION
Ref melding på Slack var det duplikater i liste i hjelpeklassen `FiksPlanMeldingtypeV2.cs`

> Tror det er en feil i versjon 1.0.0 av KS.FIKS.Plan.Models.V2: Det ser ut som OppdateringsTyper inneholder "no.ks.fiks.plan.v2.oppdatering.arealplan.oppdater.mottatt" og "no.ks.fiks.plan.v2.oppdatering.arealplan.oppdater.kvittering" to ganger.
Det medfører at valideringen vår mot skjema krasjer i lastingen av skjema-navnene.