### PR TITLE
Bruke git submodule for å hente filer fra specification prosjektet

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "fiks-plan-specification"]
+	path = fiks-plan-specification
+	url = git@github.com:ks-no/fiks-plan-specification.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "fiks-plan-specification"]
 	path = fiks-plan-specification
-	url = git@github.com:ks-no/fiks-plan-specification.git
+	url = https://github.com/ks-no/fiks-plan-specification.git
+	branch = main

--- a/GenerateModels.sh
+++ b/GenerateModels.sh
@@ -2,7 +2,7 @@
 
 GENERATOR_PATH=KS.Fiks.Plan.JsonModelGenerator
 MODELS_PATH=../KS.Fiks.Plan.Models.V2
-SCHEMA_PATH=../Schema/V2
+SCHEMA_PATH=../fiks-plan-specification/Schema/V2
 
 cd $GENERATOR_PATH
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,7 +68,7 @@ pipeline {
           steps {
             dir("${GENERATOR_FOLDER}") {
               unstash 'jsonSchemas'
-              sh 'dotnet run Schema/V2 output'
+              sh 'dotnet run fiks-plan-specification/Schema/V2 output'
               stash(name: 'generated', includes: 'output/**')
             }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,24 +42,18 @@ pipeline {
                 }
             }
         }
-        stage('Fetch specification') {
-          steps { 
-            dir('temp') {
-              git branch: params.triggerbranch,
-              url: 'https://github.com/ks-no/fiks-plan-specification.git'
-              sh 'git submodule  update --init --recursive --remote'
-          
-              dir("fiks-arkiv-specification") {
-                  sh "git fetch"
-                  sh "git checkout ${API_VERSION}"
-                  sh "git pull"
-              }
-              
-              stash(name: 'jsonSchemas', includes: 'fiks-plan-specification/Schema/V2/*')
-              stash(name: 'kodelister', includes: 'fiks-plan-specification/Schema/V2/kodelister/**/*')
-              stash(name: 'meldingstyper', includes: 'fiks-plan-specification/Schema/V2/meldingstyper/meldingstyper.json')
+        stage('Fetch and stash specification files') {
+            steps { 
+                sh 'git submodule update --init --recursive --remote'
+                dir("fiks-arkiv-specification") {
+                    sh "git fetch"
+                    sh "git checkout ${API_VERSION}"
+                    sh "git pull"
+                }
+                stash(name: 'jsonSchemas', includes: 'fiks-plan-specification/Schema/V2/*')
+                stash(name: 'kodelister', includes: 'fiks-plan-specification/Schema/V2/kodelister/**/*')
+                stash(name: 'meldingstyper', includes: 'fiks-plan-specification/Schema/V2/meldingstyper/meldingstyper.json')
             }
-          }
         }
         stage('Generate models') {
           agent {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@ pipeline {
         stage('Fetch and stash specification files') {
             steps { 
                 sh 'git submodule update --init --recursive --remote'
-                dir("fiks-arkiv-specification") {
+                dir("fiks-plan-specification") {
                     sh "git fetch"
                     sh "git checkout ${API_VERSION}"
                     sh "git pull"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,7 @@ pipeline {
         booleanParam(name: 'isRelease', defaultValue: false, description: 'Skal prosjektet releases?')
         booleanParam(name: 'pushToNugetOrg', defaultValue: false, description: 'Skal artifaktet pushes til nuget.org? Kun relevant for pre-release bygg da release alltid pushes dit')
         string(name: "specifiedVersion", defaultValue: "", description: "Hva er det nye versjonsnummeret (X.X.X)? Som default releases snapshot-versjonen")
+        string(name: "apiVersion", defaultValue: "main", description: "Hva er API versjon som skal brukes under bygg? Default er main")
         text(name: "releaseNotes", defaultValue: "Ingen endringer utført", description: "Hva er endret i denne releasen?")
         text(name: "securityReview", defaultValue: "Endringene har ingen sikkerhetskonsekvenser", description: "Har endringene sikkerhetsmessige konsekvenser, og hvilke tiltak er i så fall iverksatt?")
         string(name: "reviewer", defaultValue: "Endringene krever ikke review", description: "Hvem har gjort review?")

--- a/KS.Fiks.Plan.JsonModelGenerator/Generate.cs
+++ b/KS.Fiks.Plan.JsonModelGenerator/Generate.cs
@@ -19,6 +19,9 @@ static class Generator
     {
         "no.ks.fiks.plan.v2.felles.nasjonalarealplanid.schema.json",
         "no.ks.fiks.plan.v2.felles.flate.schema.json",
+        "no.ks.fiks.plan.v2.felles.linje.schema.json",
+        "no.ks.fiks.plan.v2.felles.handlingsomraade.schema.json",
+        "no.ks.fiks.plan.v2.felles.utnytting.schema.json",
         "no.ks.fiks.plan.v2.felles.dokument.schema.json",
         "no.ks.fiks.plan.v2.felles.posisjon.schema.json",
         "no.ks.fiks.plan.v2.felles.saksnummer.schema.json",
@@ -26,6 +29,8 @@ static class Generator
         "no.ks.fiks.plan.v2.felles.arealplan.schema.json",
         "no.ks.fiks.plan.v2.felles.planbehandling.schema.json",
         "no.ks.fiks.plan.v2.felles.midlertidigforbud.schema.json",
+        "no.ks.fiks.plan.v2.felles.planomraade.schema.json",
+        "no.ks.fiks.plan.v2.felles.arealformaalomraade.schema.json",
     };
 
     private static IEnumerable<string>? allFellesSchemas;

--- a/KS.Fiks.Plan.Models.V2.Tests/Validation/ValidateTests.cs
+++ b/KS.Fiks.Plan.Models.V2.Tests/Validation/ValidateTests.cs
@@ -15,6 +15,7 @@ namespace KS.Fiks.Plan.Models.V2.Tests.Validation;
 public class ValidateTests
 {
     private readonly ITestOutputHelper _testOutputHelper;
+    private const string SchemaPath = "./../../../../fiks-plan-specification/Schema/";
 
     public ValidateTests(ITestOutputHelper testOutputHelper)
     {
@@ -28,7 +29,7 @@ public class ValidateTests
         var isValid = false;
         var jsonPath = $"Validation/hentAktoererPayloadValid.json";
             
-        var validationSchema = GetJSchema("./../../../../Schema/V2/no.ks.fiks.plan.v2.innsyn.aktoerer.hent.schema.json");
+        var validationSchema = GetJSchema($"{SchemaPath}/V2/no.ks.fiks.plan.v2.innsyn.aktoerer.hent.schema.json");
         var json = GetJson(jsonPath);
 
         try
@@ -49,7 +50,7 @@ public class ValidateTests
         var isValid = false;
         var jsonPath = $"Validation/registrerDispensasjonPayloadValid2.json";
             
-        var validationSchema = GetJSchema("./../../../../Schema/V2/no.ks.fiks.plan.v2.oppdatering.dispensasjon.registrer.schema.json");
+        var validationSchema = GetJSchema($"{SchemaPath}/V2/no.ks.fiks.plan.v2.oppdatering.dispensasjon.registrer.schema.json");
         var json = GetJson(jsonPath);
 
         try
@@ -82,7 +83,7 @@ public class ValidateTests
         var isValid = false;
         var jsonPath = $"Validation/hentAktoererPyloadNotValid.json";
             
-        var validationSchema = GetJSchema("./../../../../Schema/V2/no.ks.fiks.plan.v2.innsyn.aktoerer.hent.schema.json");
+        var validationSchema = GetJSchema($"{SchemaPath}/V2/no.ks.fiks.plan.v2.innsyn.aktoerer.hent.schema.json");
         var json = GetJson(jsonPath);
 
         try
@@ -101,7 +102,7 @@ public class ValidateTests
     [Fact]
     public void Validate_NasjonalArealplanId()
     {
-        var jsonFileReader = File.OpenText("./../../../../Schema/V2/no.ks.fiks.plan.v2.felles.nasjonalarealplanid.schema.json");
+        var jsonFileReader = File.OpenText($"{SchemaPath}/V2/no.ks.fiks.plan.v2.felles.nasjonalarealplanid.schema.json");
         var jsonTextReader = new JsonTextReader(jsonFileReader);
         var validationSchema = JSchema.Load(jsonTextReader);
         AddAdditionalPropertiesFalseToSchemaProperties(validationSchema.Properties);
@@ -203,22 +204,22 @@ public class ValidateTests
     {
         var resolver = new JSchemaPreloadedResolver();
         // Add nasjonalarealplanid
-        var fileReader = File.OpenText("./../../../../Schema/V2/no.ks.fiks.plan.v2.felles.nasjonalarealplanid.schema.json");
+        var fileReader = File.OpenText($"{SchemaPath}/V2/no.ks.fiks.plan.v2.felles.nasjonalarealplanid.schema.json");
         resolver.Add(new Uri("no.ks.fiks.plan.v2.felles.nasjonalarealplanid.schema.json", UriKind.RelativeOrAbsolute), fileReader.ReadToEnd());
         // Add saksnummer
-        fileReader = File.OpenText("./../../../../Schema/V2/no.ks.fiks.plan.v2.felles.saksnummer.schema.json");
+        fileReader = File.OpenText($"{SchemaPath}/V2/no.ks.fiks.plan.v2.felles.saksnummer.schema.json");
         resolver.Add(new Uri("no.ks.fiks.plan.v2.felles.saksnummer.schema.json", UriKind.RelativeOrAbsolute), fileReader.ReadToEnd());
         // Add posisjon
-        fileReader = File.OpenText("./../../../../Schema/V2/no.ks.fiks.plan.v2.felles.posisjon.schema.json");
+        fileReader = File.OpenText($"{SchemaPath}/V2/no.ks.fiks.plan.v2.felles.posisjon.schema.json");
         resolver.Add(new Uri("no.ks.fiks.plan.v2.felles.posisjon.schema.json", UriKind.RelativeOrAbsolute), fileReader.ReadToEnd());
         // Add dokument
-        fileReader = File.OpenText("./../../../../Schema/V2/no.ks.fiks.plan.v2.felles.dokument.schema.json");
+        fileReader = File.OpenText($"{SchemaPath}/V2/no.ks.fiks.plan.v2.felles.dokument.schema.json");
         resolver.Add(new Uri("no.ks.fiks.plan.v2.felles.dokument.schema.json", UriKind.RelativeOrAbsolute), fileReader.ReadToEnd());
         // Add arealplan
-        fileReader = File.OpenText("./../../../../Schema/V2/no.ks.fiks.plan.v2.felles.arealplan.schema.json");
+        fileReader = File.OpenText($"{SchemaPath}/V2/no.ks.fiks.plan.v2.felles.arealplan.schema.json");
         resolver.Add(new Uri("no.ks.fiks.plan.v2.felles.arealplan.schema.json", UriKind.RelativeOrAbsolute), fileReader.ReadToEnd());
         // Add dispensasjon
-        fileReader = File.OpenText("./../../../../Schema/V2/no.ks.fiks.plan.v2.felles.dispensasjon.schema.json");
+        fileReader = File.OpenText($"{SchemaPath}/V2/no.ks.fiks.plan.v2.felles.dispensasjon.schema.json");
         resolver.Add(new Uri("no.ks.fiks.plan.v2.felles.dispensasjon.schema.json", UriKind.RelativeOrAbsolute), fileReader.ReadToEnd());
         
         var jsonFileReader = File.OpenText(schemaPath);

--- a/README.md
+++ b/README.md
@@ -21,3 +21,9 @@ Bygg-pipeline med Jenkinsfile sørger for å hente siste versjon av skjema fra s
 ## Eksempler
 
 Se [readme.md](https://github.com/ks-no/fiks-plan-models-dotnet/blob/main/KS.Fiks.Plan.Models.V2/README.md) i `KS.Fiks.Plan.Models.V2` for bruk av nuget pakken og eksempler.
+
+
+Før bygg må submodul hentes:
+```shell
+git submodule  update --init --recursive --remote
+```


### PR DESCRIPTION
Endret til å bruke git submodule for henting av skjema fra specification prosjektet.
Det var tidligere kopierte filer inn ved å sjekke ut repoet. 
Dette blir ryddigere og lettere å bygge og teste ut lokalt.
Det var også endringer som krevdes mtp nye skjema fra denne pull-requesten i specification prosjektet: https://github.com/ks-no/fiks-plan-specification/pull/134

Endret:
* Jenkinsfile
* Generator klassen så den får med seg nye felles skjema fra nye skjema i specification prosjektet
* Git submodule
